### PR TITLE
Add D9 compatibility to module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+.idea/

--- a/src/Annotation/BlockSettings.php
+++ b/src/Annotation/BlockSettings.php
@@ -51,5 +51,4 @@ class BlockSettings extends Plugin {
    * @var bool
    */
   public $area;
-
 }

--- a/src/Plugin/BlockSettings/ContextualFilter.php
+++ b/src/Plugin/BlockSettings/ContextualFilter.php
@@ -135,7 +135,7 @@ class ContextualFilter extends BlockSettingsPluginBase {
       }
       $terms = Term::loadMultiple($query->execute());
       foreach ($terms as $term) {
-        $values[$term->id()] = \Drupal::entityTypeManager()
+        $values[$term->id()] = \Drupal::service("entity.repository")
           ->getTranslationFromContext($term)
           ->label();
       }
@@ -160,8 +160,8 @@ class ContextualFilter extends BlockSettingsPluginBase {
         ];
         foreach ($validate_bundles as $bundle) {
           $terms = \Drupal::entityTypeManager()
-            ->getStorage('taxonomy_term')
-            ->loadTree($bundle);
+          ->getStorage('taxonomy_term')
+          ->loadMultiple($bundle);
           foreach ($terms as $term) {
             $values[$term->tid] = $term->name;
           }

--- a/src/Plugin/BlockSettings/ContextualFilter.php
+++ b/src/Plugin/BlockSettings/ContextualFilter.php
@@ -6,7 +6,7 @@ use Drupal\views_block_overrides\Plugin\BlockSettingsPluginBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\views\Plugin\Block\ViewsBlock;
 use Drupal\Core\Plugin\Context\Context;
-use Drupal\Core\Plugin\Context\ContextDefinition;
+use Drupal\Core\Plugin\Context\EntityContextDefinition;
 use Drupal\taxonomy\Entity\Term;
 
 /**
@@ -259,7 +259,7 @@ class ContextualFilter extends BlockSettingsPluginBase {
         if ($values['enabled']) {
           $contextual_filter_value = $values['value'];
           $contextual_filter_type = $this->getContextualFilterValidationType($id);
-          $context_definition = new ContextDefinition($contextual_filter_type, $id);
+          $context_definition = new EntityContextDefinition($contextual_filter_type, $id);
           $context_definition->setDefaultValue($contextual_filter_value);
           $block->setContext($id, new Context($context_definition, $contextual_filter_value));
         }

--- a/src/Plugin/BlockSettings/ContextualFilter.php
+++ b/src/Plugin/BlockSettings/ContextualFilter.php
@@ -135,7 +135,7 @@ class ContextualFilter extends BlockSettingsPluginBase {
       }
       $terms = Term::loadMultiple($query->execute());
       foreach ($terms as $term) {
-        $values[$term->id()] = \Drupal::entityManager()
+        $values[$term->id()] = \Drupal::entityTypeManager()
           ->getTranslationFromContext($term)
           ->label();
       }
@@ -159,7 +159,7 @@ class ContextualFilter extends BlockSettingsPluginBase {
           $options['exception']['value'] => $options['exception']['title'],
         ];
         foreach ($validate_bundles as $bundle) {
-          $terms = \Drupal::entityManager()
+          $terms = \Drupal::entityTypeManager()
             ->getStorage('taxonomy_term')
             ->loadTree($bundle);
           foreach ($terms as $term) {
@@ -167,7 +167,7 @@ class ContextualFilter extends BlockSettingsPluginBase {
           }
         }
         break;
-      // TODO more generic way to work with other entity types as well.
+        // TODO more generic way to work with other entity types as well.
       case "entity:node":
         list($entity, $entity_type) = explode(':', $validation_type);
         $options = $handler->options;
@@ -291,5 +291,4 @@ class ContextualFilter extends BlockSettingsPluginBase {
   public function getMultiValueSeparator() {
     return '+';
   }
-
 }

--- a/src/Plugin/BlockSettings/EntityReferenceTrait.php
+++ b/src/Plugin/BlockSettings/EntityReferenceTrait.php
@@ -43,10 +43,12 @@ trait EntityReferenceTrait {
     // "Warning: Invalid argument supplied for foreach()
     // in Drupal\Core\Render\Element\Checkboxes::valueCallback()"
     // @see \Drupal\user\Plugin\EntityReferenceSelection\UserSelection::buildConfigurationForm
-    if ($target_type == 'user'
+    if (
+      $target_type == 'user'
       && isset($selection_settings['filter']['type'])
       && $selection_settings['filter']['type'] == 'role'
-      && empty($selection_settings['filter']['role'])) {
+      && empty($selection_settings['filter']['role'])
+    ) {
       $selection_settings['filter']['role'] = [];
     }
 
@@ -73,7 +75,7 @@ trait EntityReferenceTrait {
 
     $subform['entity_reference'] = [
       '#type' => 'fieldset',
-      '#title' => t('Entity reference settings'),
+      '#title' => $this->t('Entity reference settings'),
       '#weight' => -40,
       '#tree' => TRUE,
       '#prefix' => '<div id="entity-reference-selection-wrapper">',
@@ -85,7 +87,7 @@ trait EntityReferenceTrait {
       '#title' => $this->t('Type of item to reference'),
       '#options' => $target_type_options,
       '#required' => TRUE,
-      '#empty_option' => t('- Select a target type -'),
+      '#empty_option' => $this->t('- Select a target type -'),
       '#default_value' => $target_type,
       '#ajax' => [
         'callback' => [get_called_class(), 'entityReferenceAjaxCallback'],
@@ -181,5 +183,4 @@ trait EntityReferenceTrait {
     $element = NestedArray::getValue($form, array_slice($button['#array_parents'], 0, -1));
     return $element;
   }
-
 }

--- a/src/Plugin/BlockSettings/EntityReferenceTrait.php
+++ b/src/Plugin/BlockSettings/EntityReferenceTrait.php
@@ -75,7 +75,7 @@ trait EntityReferenceTrait {
 
     $subform['entity_reference'] = [
       '#type' => 'fieldset',
-      '#title' => $this->t('Entity reference settings'),
+      '#title' => 'Entity reference settings',
       '#weight' => -40,
       '#tree' => TRUE,
       '#prefix' => '<div id="entity-reference-selection-wrapper">',

--- a/src/Plugin/BlockSettings/EntityTypeBundleSelectionTrait.php
+++ b/src/Plugin/BlockSettings/EntityTypeBundleSelectionTrait.php
@@ -35,7 +35,7 @@ trait EntityTypeBundleSelectionTrait {
 
     $subform['entity_reference'] = [
       '#type' => 'fieldset',
-      '#title' => t('Entity reference settings'),
+      '#title' => $this->t('Entity reference settings'),
       '#weight' => -40,
       '#prefix' => '<div id="entity-reference-selection-wrapper">',
       '#suffix' => '</div>',
@@ -46,7 +46,7 @@ trait EntityTypeBundleSelectionTrait {
       '#title' => $this->t('Type of item to reference'),
       '#options' => $target_type_options,
       '#required' => TRUE,
-      '#empty_option' => t('- Select a target type -'),
+      '#empty_option' => $this->t('- Select a target type -'),
       '#default_value' => $target_type,
       '#ajax' => [
         'callback' => [get_called_class(), 'entityTypeAjaxCallback'],
@@ -60,7 +60,7 @@ trait EntityTypeBundleSelectionTrait {
       '#title' => $this->t('Bundle'),
       '#options' => $bundle_options,
       '#required' => TRUE,
-      '#empty_option' => t('- Select a bundle type -'),
+      '#empty_option' => $this->t('- Select a bundle type -'),
       '#default_value' => $bundle_type,
     ];
 
@@ -96,7 +96,7 @@ trait EntityTypeBundleSelectionTrait {
    *   List of bundles.
    */
   public function getBundles($target_type) {
-    $options = \Drupal::entityTypeManager()
+    $options = \Drupal::service("entity_type.bundle.info")
       ->getBundleInfo($target_type);
 
     array_walk(

--- a/src/Plugin/BlockSettings/EntityTypeBundleSelectionTrait.php
+++ b/src/Plugin/BlockSettings/EntityTypeBundleSelectionTrait.php
@@ -96,13 +96,15 @@ trait EntityTypeBundleSelectionTrait {
    *   List of bundles.
    */
   public function getBundles($target_type) {
-    $options = \Drupal::entityManager()
+    $options = \Drupal::entityTypeManager()
       ->getBundleInfo($target_type);
 
-    array_walk($options,
+    array_walk(
+      $options,
       function ($item, $key) use (&$options) {
         $options[$key] = $item['label'];
-      });
+      }
+    );
 
     return $options;
   }
@@ -123,5 +125,4 @@ trait EntityTypeBundleSelectionTrait {
     $element = NestedArray::getValue($form, array_slice($button['#array_parents'], 0, -1));
     return $element;
   }
-
 }

--- a/src/Plugin/BlockSettings/EntityTypeBundleSelectionTrait.php
+++ b/src/Plugin/BlockSettings/EntityTypeBundleSelectionTrait.php
@@ -35,7 +35,7 @@ trait EntityTypeBundleSelectionTrait {
 
     $subform['entity_reference'] = [
       '#type' => 'fieldset',
-      '#title' => $this->t('Entity reference settings'),
+      '#title' => 'Entity reference settings',
       '#weight' => -40,
       '#prefix' => '<div id="entity-reference-selection-wrapper">',
       '#suffix' => '</div>',

--- a/src/Plugin/BlockSettings/InlineEntity.php
+++ b/src/Plugin/BlockSettings/InlineEntity.php
@@ -96,8 +96,8 @@ class InlineEntity extends BlockSettingsPluginBase {
    * Provide the default form for setting options.
    */
   public function buildOptionsForm(&$form, FormStateInterface $form_state) {
-   $subform = $this->buildSelectionSettingsForm($form, $form_state);
-   return $subform;
+    $subform = $this->buildSelectionSettingsForm($form, $form_state);
+    return $subform;
   }
 
   /**
@@ -148,7 +148,7 @@ class InlineEntity extends BlockSettingsPluginBase {
     $display_options = $this->getDisplayOptions();
     $entity_type = $display_options['entity_reference']['target_type'];
 
-    $options = \Drupal::entityManager()->getViewModeOptions($entity_type);
+    $options = \Drupal::entityTypeManager()->getViewModeOptions($entity_type);
 
     // Build the setting form.
     $form['view_mode'] = [
@@ -185,5 +185,4 @@ class InlineEntity extends BlockSettingsPluginBase {
 
     return $render;
   }
-
 }

--- a/src/Plugin/BlockSettings/InlineEntity.php
+++ b/src/Plugin/BlockSettings/InlineEntity.php
@@ -148,7 +148,7 @@ class InlineEntity extends BlockSettingsPluginBase {
     $display_options = $this->getDisplayOptions();
     $entity_type = $display_options['entity_reference']['target_type'];
 
-    $options = \Drupal::entityTypeManager()->getViewModeOptions($entity_type);
+    $options = \Drupal::service("entity_display.repository")->getViewModeOptions($entity_type);
 
     // Build the setting form.
     $form['view_mode'] = [

--- a/src/Plugin/BlockSettings/NodeReference.php
+++ b/src/Plugin/BlockSettings/NodeReference.php
@@ -51,7 +51,6 @@ class NodeReference extends BlockSettingsPluginBase {
       '#default_value' => $default_value,
     );
 
-   return $subform;
+    return $subform;
   }
-
 }

--- a/src/Plugin/Derivative/ViewsEntityRowDynamicFormat.php
+++ b/src/Plugin/Derivative/ViewsEntityRowDynamicFormat.php
@@ -22,9 +22,9 @@ class ViewsEntityRowDynamicFormat extends ViewsEntityRow {
    */
   public function getDerivativeDefinitions($base_plugin_definition) {
     parent::getDerivativeDefinitions($base_plugin_definition);
-    foreach ($this->entityManager->getDefinitions() as $entity_type_id => $entity_type) {
+    foreach ($this->entityTypeManager->getDefinitions() as $entity_type_id => $entity_type) {
       // Just add support for entity types which have a views integration.
-      if (($base_table = $entity_type->getBaseTable()) && $this->viewsData->get($base_table) && $this->entityManager->hasHandler($entity_type_id, 'view_builder')) {
+      if (($base_table = $entity_type->getBaseTable()) && $this->viewsData->get($base_table) && $this->entityTypeManager->hasHandler($entity_type_id, 'view_builder')) {
         $this->derivatives[$entity_type_id] = [
           'title' => 'Content (with dynamic view mode)'
         ] + $this->derivatives[$entity_type_id];
@@ -33,5 +33,4 @@ class ViewsEntityRowDynamicFormat extends ViewsEntityRow {
 
     return $this->derivatives;
   }
-
 }

--- a/src/Plugin/views/row/EntityRowWithDynamicFormat.php
+++ b/src/Plugin/views/row/EntityRowWithDynamicFormat.php
@@ -48,6 +48,6 @@ class EntityRowWithDynamicFormat extends EntityRow {
    * @return array
    */
   public function getFormatOptions() {
-    return \Drupal::entityTypeManager()->getViewModeOptions($this->entityTypeId);
+    return \Drupal::service("entity_display.repository")->getViewModeOptions($this->entityTypeId);
   }
 }

--- a/src/Plugin/views/row/EntityRowWithDynamicFormat.php
+++ b/src/Plugin/views/row/EntityRowWithDynamicFormat.php
@@ -48,7 +48,6 @@ class EntityRowWithDynamicFormat extends EntityRow {
    * @return array
    */
   public function getFormatOptions() {
-    return \Drupal::entityManager()->getViewModeOptions($this->entityTypeId);
+    return \Drupal::entityTypeManager()->getViewModeOptions($this->entityTypeId);
   }
-
 }

--- a/views_block_overrides.info.yml
+++ b/views_block_overrides.info.yml
@@ -2,6 +2,7 @@ name: Views block overrides
 type: module
 description: Allows block displays to override block configuration.
 core: 8.x
+core_version_requirement: ^8 || ^9
 package: Views
 dependencies:
   - views

--- a/views_block_overrides.module
+++ b/views_block_overrides.module
@@ -6,6 +6,7 @@ use Drupal\views\Plugin\views\display\Block as CoreBlock;
 use Drupal\ctools_views\Plugin\Display\Block as CtoolsBlock;
 use Drupal\views_block_overrides\Plugin\views\display\CtoolsBlockOverrides;
 use Drupal\views_block_overrides\Plugin\Block\ViewsBlockOverride;
+
 /**
  *  Implements hook_field_widget_FIELD-ID_FORM_alter().
  *
@@ -28,7 +29,7 @@ function views_block_overrides_field_widget_block_field_default_form_alter(&$ele
     ];
     foreach ($hiden_elements as $name) {
       if (isset($element['settings'][$name])) {
-      //  $element['settings'][$name]['#access'] = FALSE;
+        //  $element['settings'][$name]['#access'] = FALSE;
       }
     }
   }
@@ -38,9 +39,9 @@ function views_block_overrides_field_widget_block_field_default_form_alter(&$ele
  * Implements hook_views_plugins_display_alter().
  */
 function views_block_overrides_views_plugins_display_alter(&$displays) {
-//  if (!empty($displays['block']['class']) && $displays['block']['class'] == CtoolsBlock::class) {
-//    $displays['block']['class'] = CtoolsBlockOverrides::class;
-//  }
+  //  if (!empty($displays['block']['class']) && $displays['block']['class'] == CtoolsBlock::class) {
+  //    $displays['block']['class'] = CtoolsBlockOverrides::class;
+  //  }
 }
 
 /**


### PR DESCRIPTION
# Background
This module is not currently Drupal 9 compatible as shown in the `upgrade_status` report. For upgrading, the deprecated code was removed and info.yml was updated.

# Goal
- Module is D9 compatible.

# Acceptance
- Functionalities work.
- No error from `upgrade_status` and d9 compatible.

# Workflow
# Local testing
To test, I have made the same changes to `contrib/views_block_overrides` first, which got rid of the `upgrade_status` errors. Then reflecting on those changes, I have created a branch in this repo. This branch was then used in `rapp_group`  project directly using composer.json. Then checked `upgrade_status` again for errors, if any.

# Site Usable Link